### PR TITLE
feat: ghc-9.8 compatibility. ...

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,112 @@
+on: [push]
+name: Haskell Builds
+jobs:
+  build:
+    name: Haskell Build
+    runs-on: ubuntu-latest # or macOS-latest, or windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc-version:
+          - '9.8'
+        cabal-version: ['3.8.1.0']
+    steps:
+      # Checkout
+      - uses: actions/checkout@v3
+        
+      # Setup
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        id: setup
+        if: steps.tooling-cache.outputs.cache-hit != 'true'
+        with:
+          ghc-version: ${{ matrix.ghc-version }}
+          cabal-version: ${{ matrix.cabal-version }}
+
+      # Generate Plan
+      - name: Configure the Build
+        run: |
+          rm cabal.project.freeze
+          cabal configure
+          cabal build --dry-run
+
+      # Restore cache
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v3
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+
+      # Build deps (for caching)
+      - name: Cabal build dependencies
+        run: cabal build all --only-dependencies
+
+      # Save dependency cache
+      - name: Save cache
+        uses: actions/cache/save@v3
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      # Cabal build
+      - name: Cabal Bulid
+        run: cabal build all
+          
+  build-lower-bounds:
+    name: Haskell Build (lower bounds)
+    runs-on: ubuntu-latest # or macOS-latest, or windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc-version: ['9.0.1']
+        cabal-version: ['3.8.1.0']
+    steps:
+      # Checkout
+      - uses: actions/checkout@v3
+        
+      # Setup
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2
+        id: setup
+        if: steps.tooling-cache.outputs.cache-hit != 'true'
+        with:
+          ghc-version: ${{ matrix.ghc-version }}
+          cabal-version: ${{ matrix.cabal-version }}
+
+      # Generate Plan
+      - name: Configure the Build
+        run: |
+          mv cabal.project.lb cabal.project
+          rm cabal.project.freeze
+          cabal configure
+          cabal build --dry-run
+
+      # Restore cache
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v3
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+
+      # Build deps (for caching)
+      - name: Cabal build dependencies
+        run: cabal build all --only-dependencies
+
+      # Save dependency cache
+      - name: Save cache
+        uses: actions/cache/save@v3
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      # Cabal build
+      - name: Cabal Bulid
+        run: cabal build all

--- a/cabal.project.lb
+++ b/cabal.project.lb
@@ -1,0 +1,5 @@
+packages: .
+constraints:
+  aeson == 2.0.3.0,
+  base == 4.15.0.0,
+  text == 1.2.5.0

--- a/om-show.cabal
+++ b/om-show.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                om-show
-version:             0.1.2.8
+version:             0.1.2.9
 synopsis:            Utilities for showing string-like things.
 description:         Utilities for showing string-like things.
 homepage:            https://github.com/owensmurray/om-show

--- a/om-show.cabal
+++ b/om-show.cabal
@@ -19,8 +19,8 @@ extra-source-files:
 common dependencies
   build-depends:
     , aeson >= 2.0.3.0  && < 2.3
-    , base  >= 4.15.0.0 && < 4.18
-    , text  >= 1.2.5.0  && < 2.1
+    , base  >= 4.15.0.0 && < 4.20
+    , text  >= 1.2.5.0  && < 2.2
 
 common warnings
   ghc-options:


### PR DESCRIPTION
This commit expands the upper bounds of some dependencies so that the
package can be compiled with ghc-9.8.

This reverts commit 40b2760460893f8cb77d3759d9fe4c6c1ebd42d4.